### PR TITLE
Potential fix for code scanning alert no. 6: Useless assignment to local variable

### DIFF
--- a/examples/velvet/run.go
+++ b/examples/velvet/run.go
@@ -137,6 +137,9 @@ var EvaluatorNodeFn o.ConversationNodeFn = func(chatService openai.ChatService, 
 			[]a.Message{systemMsg, a.CreateMessage(a.User, prompt)},
 			conversationOptions...,
 		)
+		if err != nil {
+			return currentState, fmt.Errorf("failed to create conversation options: %w", err)
+		}
 
 		openAIOpts := o.ConvertConversationOptions(useOpts)
 


### PR DESCRIPTION
Potential fix for [https://github.com/morphy76/ggraph/security/code-scanning/6](https://github.com/morphy76/ggraph/security/code-scanning/6)

The best way to fix the problem is to handle the error returned from `a.CreateConversationOptions` directly after its assignment. This means adding an error check immediately after line 135. If `err != nil`, return an error (e.g., with a `fmt.Errorf`, as in later error checks), preserving the existing logic.  
Required changes:
- Edit the block starting at line 135 to retain the `useOpts, err := ...` assignment.
- Add a check: `if err != nil { return currentState, fmt.Errorf(..., err) }` after line 139 and before line 140.
- Ensure the error message fits the context: e.g., "failed to create conversation options".
No new imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
