### PR TITLE
Potential fix for code scanning alert no. 5: Useless assignment to local variable

### DIFF
--- a/examples/velvet/run.go
+++ b/examples/velvet/run.go
@@ -94,6 +94,9 @@ var StudentNodeFn o.ConversationNodeFn = func(chatService openai.ChatService, mo
 			[]a.Message{systemMsg, a.CreateMessage(a.User, question)},
 			conversationOptions...,
 		)
+		if err != nil {
+			return currentState, fmt.Errorf("failed to prepare student options: %w", err)
+		}
 
 		openAIOpts := o.ConvertConversationOptions(useOpts)
 


### PR DESCRIPTION
Potential fix for [https://github.com/morphy76/ggraph/security/code-scanning/5](https://github.com/morphy76/ggraph/security/code-scanning/5)

To fix this problem:
- The assignment to `err` should either be removed entirely (if the function never returns a non-nil error), or properly handled.
- The best way, for correctness and consistency (matching TeacherNodeFn), is to check and handle the error returned from `a.CreateConversationOptions`. If there is an error, return early with a suitable error message.
- This requires editing the function body of the StudentNodeFn’s returned closure, specifically the region beginning at line 92.
- No new imports or dependencies are needed.
- The fix involves adding a check immediately after `useOpts, err := ...`, similar to line 59-64 in TeacherNodeFn.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
