### PR TITLE
Potential fix for code scanning alert no. 4: Useless assignment to local variable

### DIFF
--- a/examples/velvet/run.go
+++ b/examples/velvet/run.go
@@ -56,6 +56,9 @@ var TeacherNodeFn o.ConversationNodeFn = func(chatService openai.ChatService, mo
 			[]a.Message{systemMsg, a.CreateMessage(a.User, "Genera una domanda")},
 			conversationOptions...,
 		)
+		if err != nil {
+			return currentState, fmt.Errorf("failed to create conversation options: %w", err)
+		}
 
 		openAIOpts := o.ConvertConversationOptions(useOpts)
 


### PR DESCRIPTION
Potential fix for [https://github.com/morphy76/ggraph/security/code-scanning/4](https://github.com/morphy76/ggraph/security/code-scanning/4)

To fix this issue, we should properly handle the error returned by `a.CreateConversationOptions` at line 54 before proceeding to use `useOpts`. This commonly means checking if `err` is not `nil`, returning or propagating the error early. The best way is to insert an error check immediately after the call, and to use the blank identifier `_` for the error return of the second assignment if both functions are guaranteed to succeed and error handling is not required, which in Go is usually not advised. Here, we should check `err` after creating `useOpts`, and preserve the later error handling logic. Only the snippet within lines 54–61 needs to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
