### PR TITLE
Potential fix for code scanning alert no. 3: Useless assignment to local variable

### DIFF
--- a/examples/tool/run.go
+++ b/examples/tool/run.go
@@ -126,6 +126,9 @@ func main() {
 	}
 
 	toolProcessor, err := ag.CreateToolNode("ToolProcessor", tool1, tool2)
+	if err != nil {
+		log.Fatalf("Failed to create tool processor node: %v", err)
+	}
 
 	startEdge := b.CreateStartEdge(llmWithTools)
 	toolRequestEdge := b.CreateEdge(llmWithTools, toolProcessor, map[string]string{a.RouteTagToolKey: a.RouteTagToolRequest})


### PR DESCRIPTION
Potential fix for [https://github.com/morphy76/ggraph/security/code-scanning/3](https://github.com/morphy76/ggraph/security/code-scanning/3)

The correct, safe fix is to follow the consistent error-handling pattern already established throughout this function. That is: after invoking `ag.CreateToolNode`, immediately check if `err` is non-nil and, if so, handle it appropriately (likely with `log.Fatalf`, as done elsewhere). This maintains error safety and functional consistency. You should insert an error-checking block directly after line 128, matching the handling for other similar code (lines 108-114, etc.). No new imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
