### PR TITLE
Potential fix for code scanning alert no. 2: Useless assignment to local variable

### DIFF
--- a/examples/conditional_thread/run.go
+++ b/examples/conditional_thread/run.go
@@ -28,6 +28,9 @@ func main() {
 		}
 		return nil
 	})
+	if err != nil {
+		log.Fatalf("Routing policy creation failed: %v", err)
+	}
 	routerNode, err := b.CreateRouter("operation_routing", routingPolicy)
 	if err != nil {
 		log.Fatalf("Router creation failed: %v", err)


### PR DESCRIPTION
Potential fix for [https://github.com/morphy76/ggraph/security/code-scanning/2](https://github.com/morphy76/ggraph/security/code-scanning/2)

To fix the problem, we must ensure that the error value returned by `b.CreateConditionalRoutePolicy` is inspected, and appropriate action is taken if an error is present. The best way, in keeping with how errors are handled elsewhere in the file, is to check whether `err` is non-nil after the call, and exit with a log message if so. Specifically, after line 22, add an `if err != nil { log.Fatalf(...) }` block. This is consistent with the rest of the code (see lines 32-34, 40-42, 48-50), so the fix is idiomatic. No new imports or helper methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
