### PR TITLE
Potential fix for code scanning alert no. 1: Useless assignment to local variable

### DIFF
--- a/examples/conditional/run.go
+++ b/examples/conditional/run.go
@@ -28,6 +28,9 @@ func main() {
 		}
 		return nil
 	})
+	if err != nil {
+		log.Fatalf("CreateConditionalRoutePolicy failed: %v", err)
+	}
 	routerNode, err := b.CreateRouter("operation_routing", routingPolicy)
 	if err != nil {
 		log.Fatalf("Router creation failed: %v", err)


### PR DESCRIPTION
Potential fix for [https://github.com/morphy76/ggraph/security/code-scanning/1](https://github.com/morphy76/ggraph/security/code-scanning/1)

The best way to fix the problem is to individually assign and check the `err` value returned from `b.CreateConditionalRoutePolicy`. After calling `b.CreateConditionalRoutePolicy`, check if `err` is non-nil and, if so, log a fatal error and exit. This retains all existing behavior while ensuring errors are not ignored and that there is no useless assignment to a variable that is immediately overwritten. The changes all occur within `examples/conditional/run.go`, specifically within the `main` function—no imports or external code are required, as error handling is already present in similar locations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
